### PR TITLE
Fixes arc heading always facing counter-clockwise

### DIFF
--- a/src/main/java/org/frcteam2910/common/control/PathArcSegment.java
+++ b/src/main/java/org/frcteam2910/common/control/PathArcSegment.java
@@ -10,12 +10,15 @@ public final class PathArcSegment extends PathSegment {
     private final Vector2 center;
     private final Vector2 deltaStart;
     private final Vector2 deltaEnd;
+    private final boolean clockwise;
 
     public PathArcSegment(Vector2 start, Vector2 end, Vector2 center) {
         super(start, end);
         this.center = center;
         this.deltaStart = start.subtract(center);
         this.deltaEnd = end.subtract(center);
+
+        clockwise = deltaStart.cross(deltaEnd) <= 0.0;
     }
 
     /**
@@ -62,14 +65,16 @@ public final class PathArcSegment extends PathSegment {
     @Override
     public Vector2 getPositionAtPercentage(double percentage) {
         double deltaAngle = Vector2.getAngleBetween(deltaStart, deltaEnd).toRadians() *
-                ((deltaStart.cross(deltaEnd) >= 0) ? 1 : -1) * percentage;
+                (clockwise ? -1.0 : 1.0) * percentage;
         return center.add(deltaStart.rotateBy(Rotation2.fromRadians(deltaAngle)));
     }
 
     @Override
     public Rotation2 getHeadingAtPercentage(double percentage) {
-        double angle = Vector2.getAngleBetween(deltaStart, deltaEnd).toRadians() * percentage;
-        return deltaStart.rotateBy(Rotation2.fromRadians(angle)).getAngle().normal();
+        double angle = Vector2.getAngleBetween(deltaStart, deltaEnd).toRadians() *
+                (clockwise ? -1.0 : 1.0) * percentage +
+                (clockwise ? -0.5 * Math.PI : 0.5 * Math.PI); // Add or subtract 90 degrees to the angle based on the direction of travel
+        return deltaStart.rotateBy(Rotation2.fromRadians(angle)).getAngle();
     }
 
     public Vector2 getCenter() {

--- a/src/test/java/org/frcteam2910/common/control/PathArcSegmentTest.java
+++ b/src/test/java/org/frcteam2910/common/control/PathArcSegmentTest.java
@@ -1,5 +1,6 @@
 package org.frcteam2910.common.control;
 
+import org.frcteam2910.common.math.Rotation2;
 import org.frcteam2910.common.math.Vector2;
 import org.junit.Test;
 
@@ -31,5 +32,18 @@ public class PathArcSegmentTest {
                 assertEquals(expected[i][j], actual[j]);
             }
         }
+    }
+
+    @Test
+    public void getHeadingTest() {
+        PathArcSegment segment = new PathArcSegment(new Vector2(1.0, 0.0), new Vector2(0.0, 1.0), Vector2.ZERO);
+        assertEquals(Rotation2.fromDegrees(90.0), segment.getHeadingAtPercentage(0.0));
+        assertEquals(Rotation2.fromDegrees(135.0), segment.getHeadingAtPercentage(0.5));
+        assertEquals(Rotation2.fromDegrees(180.0), segment.getHeadingAtPercentage(1.0));
+
+        segment = new PathArcSegment(new Vector2(0.0, 1.0), new Vector2(1.0, 0.0), Vector2.ZERO);
+        assertEquals(Rotation2.fromDegrees(0.0), segment.getHeadingAtPercentage(0.0));
+        assertEquals(Rotation2.fromDegrees(-45.0), segment.getHeadingAtPercentage(0.5));
+        assertEquals(Rotation2.fromDegrees(-90.0), segment.getHeadingAtPercentage(1.0));
     }
 }


### PR DESCRIPTION
<!--
Do not forget to reference any issues that you wish your PR to close if you are
creating your PR in response to a github issue. You can do this by:
  * Referring to the PR number in your commit "Fixes #00", "Closes #00"
  * Referring to the PR number in your pull request using the same style as above
For more info about how to close issues with keywords review the link below
https://help.github.com/articles/closing-issues-using-keywords/
-->
The headings calculated by `PathArcSegment` were always facing counter-clockwise, even when the direction of travel was clockwise. This checks and flips the heading if the arc's direction is clockwise. Tests have been added to verify this behavior.