### PR TITLE
Refactors, Updated Limelight Driver

### DIFF
--- a/robot/src/main/java/org/frcteam2910/common/robot/drivers/Limelight.java
+++ b/robot/src/main/java/org/frcteam2910/common/robot/drivers/Limelight.java
@@ -2,6 +2,7 @@ package org.frcteam2910.common.robot.drivers;
 
 import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableEntry;
+import edu.wpi.first.networktables.NetworkTableInstance;
 import org.frcteam2910.common.math.MathUtils;
 import org.frcteam2910.common.math.Vector2;
 
@@ -23,6 +24,14 @@ public final class Limelight {
     private final NetworkTableEntry pipeline;
     private final NetworkTableEntry stream;
     private final NetworkTableEntry snapshot;
+
+    public Limelight() {
+        this(NetworkTableInstance.getDefault().getTable("limelight"));
+    }
+
+    public Limelight(String name) {
+        this(NetworkTableInstance.getDefault().getTable("limelight-" + name));
+    }
 
     public Limelight(NetworkTable table) {
         this.table = table;

--- a/src/main/java/org/frcteam2910/common/math/MatrixUtil.java
+++ b/src/main/java/org/frcteam2910/common/math/MatrixUtil.java
@@ -1,0 +1,27 @@
+package org.frcteam2910.common.math;
+
+public class MatrixUtil {
+    /**
+     * Multiplies two matrices together
+     * @param a The first matrix
+     * @param b The second one
+     * @return A new matrix which is the product of the two given matrices
+     */
+    public static double[][] multiplyMatrices(double[][] a, double[][] b) throws IllegalArgumentException {
+        if (a[0].length != b.length) {
+            throw new IllegalArgumentException("The number of columns of the first matrix must be equal to the number of rows in the second matrix");
+        }
+        int r1 = a.length;
+        int c1 = a[0].length;
+        int c2 = b[0].length;
+        double[][] product = new double[r1][c2];
+        for (int i = 0; i < r1; i++) {
+            for (int j = 0; j < c2; j++) {
+                for (int k = 0; k < c1; k++) {
+                    product[i][j] += a[i][k] * b[k][j];
+                }
+            }
+        }
+        return product;
+    }
+}

--- a/src/main/java/org/frcteam2910/common/math/Rotation3.java
+++ b/src/main/java/org/frcteam2910/common/math/Rotation3.java
@@ -2,6 +2,8 @@ package org.frcteam2910.common.math;
 
 import java.text.DecimalFormat;
 
+import static org.frcteam2910.common.math.MatrixUtil.multiplyMatrices;
+
 /**
  * This represents a rotation in 3d space through a rotation matrix and its corresponding euler angles
  */
@@ -42,27 +44,6 @@ public class Rotation3 {
      */
     public Rotation3 add(Rotation3 other) {
         return new Rotation3(multiplyMatrices(this.rotationMatrix, other.rotationMatrix));
-    }
-
-    /**
-     * Multiplies two matrices together
-     * @param a The first matrix
-     * @param b The second one
-     * @return A new matrix which is the product of the two given matrices
-     */
-    public static double[][] multiplyMatrices(double[][] a, double[][] b) {
-        int r1 = a.length;
-        int c1 = a[0].length;
-        int c2 = b[0].length;
-        double[][] product = new double[r1][c2];
-        for (int i = 0; i < r1; i++) {
-            for (int j = 0; j < c2; j++) {
-                for (int k = 0; k < c1; k++) {
-                    product[i][j] += a[i][k] * b[k][j];
-                }
-            }
-        }
-        return product;
     }
 
     /**


### PR DESCRIPTION
<!--
Do not forget to reference any issues that you wish your PR to close if you are
creating your PR in response to a github issue. You can do this by:
  * Referring to the PR number in your commit "Fixes #00", "Closes #00"
  * Referring to the PR number in your pull request using the same style as above
For more info about how to close issues with keywords review the link below
https://help.github.com/articles/closing-issues-using-keywords/
-->
This updates the Limelight driver so it has a default constructor and another useful one which will take the name of the Limelight. For example, if the name of your Limelight is "limelight-hatch", you would pass "hatch" to the constructor. This was done since you can't remove the "limelight-" prefix from the name of a Limelight. Also, the `multiplyMatrices()` function found originally in `Rotation3` has been moved to the new `MatrixUtil` class.