### PR TITLE
Continuous should default to false

### DIFF
--- a/src/main/java/org/frcteam2910/common/control/PidController.java
+++ b/src/main/java/org/frcteam2910/common/control/PidController.java
@@ -7,7 +7,7 @@ public class PidController {
 
     private double setpoint;
 
-    private boolean continuous = true;
+    private boolean continuous = false;
     private double inputRange = Double.POSITIVE_INFINITY;
     private double minOutput = Double.NEGATIVE_INFINITY;
     private double maxOutput = Double.POSITIVE_INFINITY;


### PR DESCRIPTION
PIDController's continuous should default to false (according to people at the programming meeting)

(Didn't bother building an issue for this one since the fix is literally just one line)
<!--
Do not forget to reference any issues that you wish your PR to close if you are
creating your PR in response to a github issue. You can do this by:
  * Referring to the PR number in your commit "Fixes #00", "Closes #00"
  * Referring to the PR number in your pull request using the same style as above
For more info about how to close issues with keywords review the link below
https://help.github.com/articles/closing-issues-using-keywords/
-->
