### PR TITLE
Fixes incorrect line in build.gradle

### DIFF
--- a/robot/build.gradle
+++ b/robot/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 sourceCompatibility = JavaVersion.VERSION_11
-sourceCompatibility = JavaVersion.VERSION_11
+targetCompatibility = JavaVersion.VERSION_11
 
 group = 'org.frcteam2910.common'
 version = '2019.0.0'


### PR DESCRIPTION
The `targetCompatibility` field in the robot project's `build.gradle` wasn't being set when it should be. Instead `sourceCompatibility` was being set twice. This would have caused issues for anyone who is trying to deploy this library to the RoboRIO and used a JDK newer than JDK 11.