### PR TITLE
Add SDS Mk2 swerve module builder

### DIFF
--- a/examples/swerve-robot/src/main/java/frc/swerverobot/subsystems/DrivetrainSubsystem.java
+++ b/examples/swerve-robot/src/main/java/frc/swerverobot/subsystems/DrivetrainSubsystem.java
@@ -12,6 +12,7 @@ import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardLayout;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import frc.swerverobot.commands.DriveCommand;
+import org.frcteam2910.common.drivers.SwerveModule;
 import org.frcteam2910.common.kinematics.ChassisVelocity;
 import org.frcteam2910.common.kinematics.SwerveKinematics;
 import org.frcteam2910.common.kinematics.SwerveOdometry;
@@ -19,7 +20,7 @@ import org.frcteam2910.common.math.RigidTransform2;
 import org.frcteam2910.common.math.Rotation2;
 import org.frcteam2910.common.math.Vector2;
 import org.frcteam2910.common.robot.UpdateManager;
-import org.frcteam2910.common.robot.drivers.Mk2SwerveModule;
+import org.frcteam2910.common.robot.drivers.Mk2SwerveModuleBuilder;
 import org.frcteam2910.common.robot.drivers.NavX;
 import org.frcteam2910.common.util.HolonomicDriveSignal;
 
@@ -31,35 +32,55 @@ public class DrivetrainSubsystem extends Subsystem implements UpdateManager.Upda
 
     private static final DrivetrainSubsystem instance;
 
-    private final Mk2SwerveModule frontLeftModule = new Mk2SwerveModule(
-            new Vector2(TRACKWIDTH / 2.0, -WHEELBASE / 2.0),
-            DRIVETRAIN_FRONT_LEFT_MODULE_ANGLE_OFFSET,
-            new Spark(DRIVETRAIN_FRONT_LEFT_MODULE_ANGLE_MOTOR),
-            new CANSparkMax(DRIVETRAIN_FRONT_LEFT_MODULE_DRIVE_MOTOR, CANSparkMaxLowLevel.MotorType.kBrushless),
-            new AnalogInput(DRIVETRAIN_FRONT_LEFT_MODULE_ANGLE_ENCODER)
-    );
-    private final Mk2SwerveModule frontRightModule = new Mk2SwerveModule(
-            new Vector2(TRACKWIDTH / 2.0, WHEELBASE / 2.0),
-            DRIVETRAIN_FRONT_RIGHT_MODULE_ANGLE_OFFSET,
-            new Spark(DRIVETRAIN_FRONT_RIGHT_MODULE_ANGLE_MOTOR),
-            new CANSparkMax(DRIVETRAIN_FRONT_RIGHT_MODULE_DRIVE_MOTOR, CANSparkMaxLowLevel.MotorType.kBrushless),
-            new AnalogInput(DRIVETRAIN_FRONT_RIGHT_MODULE_ANGLE_ENCODER)
-    );
-    private final Mk2SwerveModule backLeftModule = new Mk2SwerveModule(
-            new Vector2(-TRACKWIDTH / 2.0, -WHEELBASE / 2.0),
-            DRIVETRAIN_BACK_LEFT_MODULE_ANGLE_OFFSET,
-            new Spark(DRIVETRAIN_BACK_LEFT_MODULE_ANGLE_MOTOR),
-            new CANSparkMax(DRIVETRAIN_BACK_LEFT_MODULE_DRIVE_MOTOR, CANSparkMaxLowLevel.MotorType.kBrushless),
-            new AnalogInput(DRIVETRAIN_BACK_LEFT_MODULE_ANGLE_ENCODER)
-    );
-    private final Mk2SwerveModule backRightModule = new Mk2SwerveModule(
-            new Vector2(-TRACKWIDTH / 2.0, WHEELBASE / 2.0),
-            DRIVETRAIN_BACK_RIGHT_MODULE_ANGLE_OFFSET,
-            new Spark(DRIVETRAIN_BACK_RIGHT_MODULE_ANGLE_MOTOR),
-            new CANSparkMax(DRIVETRAIN_BACK_RIGHT_MODULE_DRIVE_MOTOR, CANSparkMaxLowLevel.MotorType.kBrushless),
-            new AnalogInput(DRIVETRAIN_BACK_RIGHT_MODULE_ANGLE_ENCODER)
-    );
-    private final Mk2SwerveModule[] modules = {frontLeftModule, frontRightModule, backLeftModule, backRightModule};
+    private final SwerveModule frontLeftModule =
+            new Mk2SwerveModuleBuilder(new Vector2(TRACKWIDTH / 2.0, -WHEELBASE / 2.0))
+                    .angleEncoder(
+                            new AnalogInput(DRIVETRAIN_FRONT_LEFT_MODULE_ANGLE_ENCODER),
+                            DRIVETRAIN_FRONT_LEFT_MODULE_ANGLE_OFFSET)
+                    .angleMotor(
+                            new Spark(DRIVETRAIN_FRONT_LEFT_MODULE_ANGLE_MOTOR),
+                            Mk2SwerveModuleBuilder.MotorType.NEO)
+                    .driveMotor(
+                            new CANSparkMax(DRIVETRAIN_FRONT_LEFT_MODULE_DRIVE_MOTOR, CANSparkMaxLowLevel.MotorType.kBrushless),
+                            Mk2SwerveModuleBuilder.MotorType.NEO)
+                    .build();
+    private final SwerveModule frontRightModule =
+            new Mk2SwerveModuleBuilder(new Vector2(TRACKWIDTH / 2.0, WHEELBASE / 2.0))
+                    .angleEncoder(
+                            new AnalogInput(DRIVETRAIN_FRONT_RIGHT_MODULE_ANGLE_ENCODER),
+                            DRIVETRAIN_FRONT_RIGHT_MODULE_ANGLE_OFFSET)
+                    .angleMotor(
+                            new Spark(DRIVETRAIN_FRONT_RIGHT_MODULE_ANGLE_MOTOR),
+                            Mk2SwerveModuleBuilder.MotorType.NEO)
+                    .driveMotor(
+                            new CANSparkMax(DRIVETRAIN_FRONT_RIGHT_MODULE_DRIVE_MOTOR, CANSparkMaxLowLevel.MotorType.kBrushless),
+                            Mk2SwerveModuleBuilder.MotorType.NEO)
+                    .build();
+    private final SwerveModule backLeftModule =
+            new Mk2SwerveModuleBuilder(new Vector2(-TRACKWIDTH / 2.0, -WHEELBASE / 2.0))
+                    .angleEncoder(
+                            new AnalogInput(DRIVETRAIN_BACK_LEFT_MODULE_ANGLE_ENCODER),
+                            DRIVETRAIN_BACK_LEFT_MODULE_ANGLE_OFFSET)
+                    .angleMotor(
+                            new Spark(DRIVETRAIN_BACK_LEFT_MODULE_ANGLE_MOTOR),
+                            Mk2SwerveModuleBuilder.MotorType.NEO)
+                    .driveMotor(
+                            new CANSparkMax(DRIVETRAIN_BACK_LEFT_MODULE_DRIVE_MOTOR, CANSparkMaxLowLevel.MotorType.kBrushless),
+                            Mk2SwerveModuleBuilder.MotorType.NEO)
+                    .build();
+    private final SwerveModule backRightModule =
+            new Mk2SwerveModuleBuilder(new Vector2(-TRACKWIDTH / 2.0, WHEELBASE / 2.0))
+                    .angleEncoder(
+                            new AnalogInput(DRIVETRAIN_BACK_RIGHT_MODULE_ANGLE_ENCODER),
+                            DRIVETRAIN_BACK_RIGHT_MODULE_ANGLE_OFFSET)
+                    .angleMotor(
+                            new Spark(DRIVETRAIN_BACK_RIGHT_MODULE_ANGLE_MOTOR),
+                            Mk2SwerveModuleBuilder.MotorType.NEO)
+                    .driveMotor(
+                            new CANSparkMax(DRIVETRAIN_BACK_RIGHT_MODULE_DRIVE_MOTOR, CANSparkMaxLowLevel.MotorType.kBrushless),
+                            Mk2SwerveModuleBuilder.MotorType.NEO)
+                    .build();
+    private final SwerveModule[] modules = {frontLeftModule, frontRightModule, backLeftModule, backRightModule};
 
     private final SwerveKinematics kinematics = new SwerveKinematics(
             new Vector2(TRACKWIDTH / 2.0, WHEELBASE / 2.0), // Front Left

--- a/robot/src/main/java/org/frcteam2910/common/robot/drivers/Mk2SwerveModuleBuilder.java
+++ b/robot/src/main/java/org/frcteam2910/common/robot/drivers/Mk2SwerveModuleBuilder.java
@@ -1,0 +1,243 @@
+package org.frcteam2910.common.robot.drivers;
+
+import com.revrobotics.CANEncoder;
+import com.revrobotics.CANPIDController;
+import com.revrobotics.CANSparkMax;
+import com.revrobotics.ControlType;
+import edu.wpi.first.wpilibj.AnalogInput;
+import edu.wpi.first.wpilibj.RobotController;
+import edu.wpi.first.wpilibj.SpeedController;
+import org.frcteam2910.common.control.PidConstants;
+import org.frcteam2910.common.control.PidController;
+import org.frcteam2910.common.drivers.SwerveModule;
+import org.frcteam2910.common.math.Vector2;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.DoubleConsumer;
+import java.util.function.DoubleSupplier;
+
+public class Mk2SwerveModuleBuilder {
+    /**
+     * The gear ratio of the angle motor that ships with the standard kit.
+     */
+    private static final double DEFAULT_ANGLE_REDUCTION = 18.0 / 1.0;
+
+    /**
+     * The gear ratio of the drive motor that ships with the standard kit.
+     */
+    private static final double DEFAULT_DRIVE_REDUCTION = 8.31 / 1.0;
+
+    /**
+     * The diameter of the standard wheel in inches.
+     */
+    private static final double DEFAULT_WHEEL_DIAMETER = 4.0;
+
+    /**
+     * Default constants for angle pid running on-board when running NEOs.
+     */
+    private static final PidConstants DEFAULT_ONBOARD_ANGLE_CONSTANTS = new PidConstants(0.5, 0.0, 0.0001);
+
+    /**
+     * Default constants for angle pid running on a Spark MAX using NEOs.
+     */
+    private static final PidConstants DEFAULT_CAN_SPARK_MAX_ANGLE_CONSTANTS = new PidConstants(1.5, 0.0, 0.5);
+
+    private final Vector2 modulePosition;
+
+    private DoubleSupplier angleSupplier;
+    private DoubleSupplier currentDrawSupplier;
+    private DoubleSupplier distanceSupplier;
+    private DoubleSupplier velocitySupplier;
+
+    private DoubleConsumer driveOutputConsumer;
+    private DoubleConsumer targetAngleConsumer;
+
+    private DoubleConsumer initializeAngleCallback;
+    private List<BiConsumer<SwerveModule, Double>> updateCallbacks = new ArrayList<>();
+
+    public Mk2SwerveModuleBuilder(Vector2 modulePosition) {
+        this.modulePosition = modulePosition;
+    }
+
+    public Mk2SwerveModuleBuilder angleEncoder(AnalogInput encoder, double offset) {
+        angleSupplier = () -> {
+            double angle = (1.0 - encoder.getVoltage() / RobotController.getVoltage5V()) * 2.0 * Math.PI;
+            angle += offset;
+            angle %= 2.0 * Math.PI;
+            if (angle < 0.0) {
+                angle += 2.0 * Math.PI;
+            }
+
+            return angle;
+        };
+
+        return this;
+    }
+
+    public Mk2SwerveModuleBuilder angleMotor(CANSparkMax motor) {
+        return angleMotor(motor, DEFAULT_CAN_SPARK_MAX_ANGLE_CONSTANTS, DEFAULT_ANGLE_REDUCTION);
+    }
+
+    public Mk2SwerveModuleBuilder angleMotor(CANSparkMax motor, PidConstants constants, double reduction) {
+        CANEncoder encoder = motor.getEncoder();
+        encoder.setPositionConversionFactor(2.0 * Math.PI / reduction);
+
+        CANPIDController controller = motor.getPIDController();
+
+        controller.setP(constants.p);
+        controller.setI(constants.i);
+        controller.setD(constants.i);
+
+        targetAngleConsumer = targetAngle -> {
+            double currentAngle = encoder.getPosition();
+            // Calculate the current angle in the range [0, 2pi)
+            double currentAngleMod = currentAngle % (2.0 * Math.PI);
+            if (currentAngleMod < 0.0) {
+                currentAngleMod += 2.0 * Math.PI;
+            }
+
+            // Figure out target to send to Spark MAX because the encoder is continuous
+            double newTarget = targetAngle + currentAngle - currentAngleMod;
+            if (targetAngle - currentAngleMod > Math.PI) {
+                newTarget -= 2.0 * Math.PI;
+            } else if (targetAngle - currentAngleMod < -Math.PI) {
+                newTarget += 2.0 * Math.PI;
+            }
+
+            controller.setReference(newTarget, ControlType.kPosition);
+        };
+        initializeAngleCallback = encoder::setPosition;
+
+        return this;
+    }
+
+    public Mk2SwerveModuleBuilder angleMotor(SpeedController motor) {
+        return angleMotor(motor, DEFAULT_ONBOARD_ANGLE_CONSTANTS);
+    }
+
+    public Mk2SwerveModuleBuilder angleMotor(SpeedController motor, PidConstants constants) {
+        PidController controller = new PidController(constants);
+        controller.setInputRange(0.0, 2.0 * Math.PI);
+        controller.setContinuous(true);
+
+        targetAngleConsumer = controller::setSetpoint;
+        updateCallbacks.add((module, dt) -> motor.set(controller.calculate(module.getCurrentAngle(), dt)));
+
+        return this;
+    }
+
+    public Mk2SwerveModuleBuilder driveMotor(CANSparkMax motor) {
+        return driveMotor(motor, DEFAULT_DRIVE_REDUCTION, DEFAULT_WHEEL_DIAMETER);
+    }
+
+    public Mk2SwerveModuleBuilder driveMotor(CANSparkMax motor, double reduction, double wheelDiameter) {
+        CANEncoder encoder = motor.getEncoder();
+        encoder.setPositionConversionFactor(wheelDiameter * Math.PI / reduction);
+        encoder.setVelocityConversionFactor(wheelDiameter * Math.PI / reduction * (1.0 / 60.0)); // RPM to units per second
+
+        currentDrawSupplier = motor::getOutputCurrent;
+        distanceSupplier = encoder::getPosition;
+        velocitySupplier = encoder::getVelocity;
+        driveOutputConsumer = motor::set;
+
+        return this;
+    }
+
+    public SwerveModule build() {
+        // Verify everything is populated
+        if (angleSupplier == null) {
+            // Absolute angle encoder not configured
+            throw new IllegalStateException(""); // TODO: Exception message
+        } else if (currentDrawSupplier == null) {
+            // Current draw not configured
+            throw new IllegalStateException(""); // TODO: Exception message
+        } else if (distanceSupplier == null || velocitySupplier == null) {
+            // Drive encoder not configured
+            throw new IllegalStateException(""); // TODO: Exception message
+        } else if (driveOutputConsumer == null) {
+            // Drive motor not configured
+            throw new IllegalStateException(""); // TODO: Exception message
+        } else if (targetAngleConsumer == null) {
+            // Angle motor not configured
+            throw new IllegalStateException(""); // TODO: Exception message
+        }
+
+        return new SwerveModuleImpl();
+    }
+
+    private final class SwerveModuleImpl extends SwerveModule {
+        private final Object sensorLock = new Object();
+        private double currentDraw = 0.0;
+        private double velocity = 0.0;
+
+        public SwerveModuleImpl() {
+            super(modulePosition);
+
+            initializeAngleCallback.accept(angleSupplier.getAsDouble());
+        }
+
+        @Override
+        protected double readAngle() {
+            return angleSupplier.getAsDouble();
+        }
+
+        protected double readCurrentDraw() {
+            return currentDrawSupplier.getAsDouble();
+        }
+
+        @Override
+        protected double readDistance() {
+            return distanceSupplier.getAsDouble();
+        }
+
+        protected double readVelocity() {
+            return velocitySupplier.getAsDouble();
+        }
+
+        @Override
+        public double getCurrentVelocity() {
+            synchronized (sensorLock) {
+                return velocity;
+            }
+        }
+
+        @Override
+        public double getDriveCurrent() {
+            synchronized (sensorLock) {
+                return currentDraw;
+            }
+        }
+
+        @Override
+        protected void setTargetAngle(double angle) {
+            targetAngleConsumer.accept(angle);
+        }
+
+        @Override
+        protected void setDriveOutput(double output) {
+            driveOutputConsumer.accept(output);
+        }
+
+        @Override
+        public void updateSensors() {
+            super.updateSensors();
+
+            double newCurrentDraw = readCurrentDraw();
+            double newVelocity = readVelocity();
+
+            synchronized (sensorLock) {
+                currentDraw = newCurrentDraw;
+                velocity = newVelocity;
+            }
+        }
+
+        @Override
+        public void updateState(double dt) {
+            super.updateState(dt);
+
+            updateCallbacks.forEach(c -> c.accept(this, dt));
+        }
+    }
+}

--- a/robot/src/main/java/org/frcteam2910/common/robot/drivers/Mk2SwerveModuleBuilder.java
+++ b/robot/src/main/java/org/frcteam2910/common/robot/drivers/Mk2SwerveModuleBuilder.java
@@ -61,6 +61,13 @@ public class Mk2SwerveModuleBuilder {
         this.modulePosition = modulePosition;
     }
 
+    /**
+     * Configures the swerve module to use an analog encoder through one of the RoboRIO's analog input ports.
+     *
+     * @param encoder The analog input handle to use for the encoder.
+     * @param offset  The offset of the encoder in radians. This value is added to the analog encoder reading to obtain
+     *                the true module angle.
+     */
     public Mk2SwerveModuleBuilder angleEncoder(AnalogInput encoder, double offset) {
         angleSupplier = () -> {
             double angle = (1.0 - encoder.getVoltage() / RobotController.getVoltage5V()) * 2.0 * Math.PI;
@@ -76,10 +83,33 @@ public class Mk2SwerveModuleBuilder {
         return this;
     }
 
+    /**
+     * Configures the swerve module to use a CAN Spark MAX driving a NEO as it's angle motor.
+     * <p>
+     * The default PID constants and angle reduction are used. These values have been determined to work with all Mk2
+     * modules controlled by this motor.
+     * <p>
+     * To override this values see {@link #angleMotor(CANSparkMax, PidConstants, double)}
+     *
+     * @param motor The CAN Spark MAX to use as the angle motor. The NEO's encoder is set to output the module's angle
+     *              in radians.
+     */
     public Mk2SwerveModuleBuilder angleMotor(CANSparkMax motor) {
         return angleMotor(motor, DEFAULT_CAN_SPARK_MAX_ANGLE_CONSTANTS, DEFAULT_ANGLE_REDUCTION);
     }
 
+    /**
+     * Configures the swerve module to use a CAN Spark MAX driving a NEO as it's angle motor.
+     * <p>
+     * This method is usually used when custom PID tuning is required. If using the standard angle reduction
+     * and a NEO, {@link #angleMotor(CANSparkMax)} uses already tuned constants so no tuning is required.
+     *
+     * @param motor     The CAN Spark MAX to use as the angle motor. The NEO's encoder is set to output the module's
+     *                  angle in radians.
+     * @param constants The PID constants to use to control the module's angle (Units are in radians).
+     * @param reduction The reduction of the angle motor. It should be specified so the number is greater than 1.
+     *                  For example, an 18:1 ratio should be specified by {@code 18.0 / 1.0}.
+     */
     public Mk2SwerveModuleBuilder angleMotor(CANSparkMax motor, PidConstants constants, double reduction) {
         CANEncoder encoder = motor.getEncoder();
         encoder.setPositionConversionFactor(2.0 * Math.PI / reduction);
@@ -113,10 +143,26 @@ public class Mk2SwerveModuleBuilder {
         return this;
     }
 
+    /**
+     * Configures the swerve module to use a PWM Spark MAX driving a NEO as it's angle motor.
+     * <p>
+     * The default PID constants are used. These values have been determined to work with all Mk2 modules
+     * controlled by a NEO using the standard angle reduction.
+     *
+     * @param motor The PWM Spark MAX to use as the angle motor.
+     */
     public Mk2SwerveModuleBuilder angleMotor(SpeedController motor) {
         return angleMotor(motor, DEFAULT_ONBOARD_ANGLE_CONSTANTS);
     }
 
+    /**
+     * Configures the swerve module to use a generic speed controller as it's angle motor.
+     * <p>
+     * This method is usually used when custom PID tuning is required or a NEO is not used.
+     *
+     * @param motor     The speed controller to use as the angle motor.
+     * @param constants The PID constants to use to control the module's angle (Units are in radians).
+     */
     public Mk2SwerveModuleBuilder angleMotor(SpeedController motor, PidConstants constants) {
         PidController controller = new PidController(constants);
         controller.setInputRange(0.0, 2.0 * Math.PI);
@@ -128,10 +174,30 @@ public class Mk2SwerveModuleBuilder {
         return this;
     }
 
+    /**
+     * Configures the swerve module to use a CAN Spark MAX driving a NEO as it's drive motor.
+     * <p>
+     * The default reduction and wheel diameter are used. These will work with the recommended wheel and stock drive
+     * reduction. By default distance and velocity will be reported in inches and inches per second.
+     *
+     * @param motor The CAN Spark MAX to use as the drive motor. The NEO's encoder is set to output the module's driven
+     *              distance and current velocity in inches and inches per second.
+     */
     public Mk2SwerveModuleBuilder driveMotor(CANSparkMax motor) {
         return driveMotor(motor, DEFAULT_DRIVE_REDUCTION, DEFAULT_WHEEL_DIAMETER);
     }
 
+    /**
+     * Configures the swerve module to use a CAN Spark MAX driving a NEO as it's drive motor.
+     *
+     * @param motor         The CAN Spark MAX to use as the drive motor. The NEO's encoder is set to output the module's driven
+     *                      distance and current velocity. Units are the same as the units used for the wheel diameter.
+     * @param reduction     The drive reduction of the module. It should be specified so the number is greater than 1.
+     *                      For example, an 18:1 ratio should be specified by {@code 18.0 / 1.0}.
+     * @param wheelDiameter The diameter of the module's wheel. By default this is {@value DEFAULT_WHEEL_DIAMETER}
+     *                      inches.
+     * @return
+     */
     public Mk2SwerveModuleBuilder driveMotor(CANSparkMax motor, double reduction, double wheelDiameter) {
         CANEncoder encoder = motor.getEncoder();
         encoder.setPositionConversionFactor(wheelDiameter * Math.PI / reduction);
@@ -145,6 +211,9 @@ public class Mk2SwerveModuleBuilder {
         return this;
     }
 
+    /**
+     * Builds and returns a configured swerve module.
+     */
     public SwerveModule build() {
         // Verify everything is populated
         if (angleSupplier == null) {

--- a/robot/src/main/java/org/frcteam2910/common/robot/drivers/Mk2SwerveModuleBuilder.java
+++ b/robot/src/main/java/org/frcteam2910/common/robot/drivers/Mk2SwerveModuleBuilder.java
@@ -67,6 +67,7 @@ public class Mk2SwerveModuleBuilder {
      * @param encoder The analog input handle to use for the encoder.
      * @param offset  The offset of the encoder in radians. This value is added to the analog encoder reading to obtain
      *                the true module angle.
+     * @return The builder.
      */
     public Mk2SwerveModuleBuilder angleEncoder(AnalogInput encoder, double offset) {
         angleSupplier = () -> {
@@ -93,6 +94,7 @@ public class Mk2SwerveModuleBuilder {
      *
      * @param motor The CAN Spark MAX to use as the angle motor. The NEO's encoder is set to output the module's angle
      *              in radians.
+     * @return The builder.
      */
     public Mk2SwerveModuleBuilder angleMotor(CANSparkMax motor) {
         return angleMotor(motor, DEFAULT_CAN_SPARK_MAX_ANGLE_CONSTANTS, DEFAULT_ANGLE_REDUCTION);
@@ -106,9 +108,10 @@ public class Mk2SwerveModuleBuilder {
      *
      * @param motor     The CAN Spark MAX to use as the angle motor. The NEO's encoder is set to output the module's
      *                  angle in radians.
-     * @param constants The PID constants to use to control the module's angle (Units are in radians).
+     * @param constants The PID constants to use to control the module's angle (units are in radians).
      * @param reduction The reduction of the angle motor. It should be specified so the number is greater than 1.
      *                  For example, an 18:1 ratio should be specified by {@code 18.0 / 1.0}.
+     * @return The builder.
      */
     public Mk2SwerveModuleBuilder angleMotor(CANSparkMax motor, PidConstants constants, double reduction) {
         CANEncoder encoder = motor.getEncoder();
@@ -150,6 +153,7 @@ public class Mk2SwerveModuleBuilder {
      * controlled by a NEO using the standard angle reduction.
      *
      * @param motor The PWM Spark MAX to use as the angle motor.
+     * @return The builder.
      */
     public Mk2SwerveModuleBuilder angleMotor(SpeedController motor) {
         return angleMotor(motor, DEFAULT_ONBOARD_ANGLE_CONSTANTS);
@@ -161,7 +165,8 @@ public class Mk2SwerveModuleBuilder {
      * This method is usually used when custom PID tuning is required or a NEO is not used.
      *
      * @param motor     The speed controller to use as the angle motor.
-     * @param constants The PID constants to use to control the module's angle (Units are in radians).
+     * @param constants The PID constants to use to control the module's angle (units are in radians).
+     * @return The builder.
      */
     public Mk2SwerveModuleBuilder angleMotor(SpeedController motor, PidConstants constants) {
         PidController controller = new PidController(constants);
@@ -182,6 +187,7 @@ public class Mk2SwerveModuleBuilder {
      *
      * @param motor The CAN Spark MAX to use as the drive motor. The NEO's encoder is set to output the module's driven
      *              distance and current velocity in inches and inches per second.
+     * @return The builder.
      */
     public Mk2SwerveModuleBuilder driveMotor(CANSparkMax motor) {
         return driveMotor(motor, DEFAULT_DRIVE_REDUCTION, DEFAULT_WHEEL_DIAMETER);
@@ -196,7 +202,7 @@ public class Mk2SwerveModuleBuilder {
      *                      For example, an 18:1 ratio should be specified by {@code 18.0 / 1.0}.
      * @param wheelDiameter The diameter of the module's wheel. By default this is {@value DEFAULT_WHEEL_DIAMETER}
      *                      inches.
-     * @return
+     * @return The builder.
      */
     public Mk2SwerveModuleBuilder driveMotor(CANSparkMax motor, double reduction, double wheelDiameter) {
         CANEncoder encoder = motor.getEncoder();
@@ -213,6 +219,8 @@ public class Mk2SwerveModuleBuilder {
 
     /**
      * Builds and returns a configured swerve module.
+     *
+     * @return The built swerve module.
      */
     public SwerveModule build() {
         // Verify everything is populated

--- a/robot/src/main/java/org/frcteam2910/common/robot/drivers/Mk2SwerveModuleBuilder.java
+++ b/robot/src/main/java/org/frcteam2910/common/robot/drivers/Mk2SwerveModuleBuilder.java
@@ -295,13 +295,13 @@ public class Mk2SwerveModuleBuilder {
         // Verify everything is populated
         if (angleSupplier == null) {
             // Absolute angle encoder not configured
-            throw new IllegalStateException(""); // TODO: Exception message
+            throw new IllegalStateException("No absolute encoder has been configured! See Mk2SwerveModuleBuilder.angleEncoder");
         } else if (driveOutputConsumer == null) {
             // Drive motor not configured
-            throw new IllegalStateException(""); // TODO: Exception message
+            throw new IllegalStateException("No drive motor has been configured! See Mk2SwerveModuleBuilder.driveMotor");
         } else if (targetAngleConsumer == null) {
             // Angle motor not configured
-            throw new IllegalStateException(""); // TODO: Exception message
+            throw new IllegalStateException("No angle motor has been configured! See Mk2SwerveModuleBuilder.angleMotor");
         }
 
         return new SwerveModuleImpl();


### PR DESCRIPTION
Adds a builder for different configurations of the SDS Mk2 swerve module. The builder contains default PID constants as well as reductions for the encoders but these can be overridden by the user through method overloads.

Absolute encoder support:
* Analog encoders using RoboRIO's analog inputs

Angle motor support:
* NEOs controlled by any motor controller over CAN and PWM
    * Special case for CAN Spark MAX that moves PID control onto the Spark
* Mini CIMs and CIMs controlled by any motor controller

Drive motor support:
* NEOs controlled by any motor controller over CAN and PWM
* Mini CIMs and CIMs controlled by any motor controller

Sample API usage:
```java
// Absolute encoder: Analog encoder
// Angle motor: NEO controlled over CAN
// Drive motor: NEO controlled over CAN
SwerveModule module = new Mk2SwerveModuleBuilder(new Vector2(5.0, 5.0))
    .angleEncoder(new AnalogInput(0), -Math.toRadians(254.16))
    .angleMotor(new CANSparkMax(1, CANSparkMaxLowLevel.MotorType.kBrushless))
    .driveMotor(new CANSparkMax(2, CANSparkMaxLowLevel.MotorType.kBrushless))
    .build();
```

```java
// Absolute encoder: Analog encoder
// Angle motor: NEO controlled over PWM
//     Custom PID constants
// Drive motor: NEO controlled over CAN
SwerveModule module = new Mk2SwerveModuleBuilder(new Vector2(5.0, 5.0))
    .angleEncoder(new AnalogInput(0), -Math.toRadians(330.148))
    .angleMotor(new Spark(4), new PidConstants(1.0, 0.0, 0.001))
    .driveMotor(new CANSparkMax(4, CANSparkMaxLowLevel.MotorType.kBrushless))
    .build();
```

```java
// Absolute encoder: Analog encoder
// Angle motor: CIM controlled over CAN using a Talon SRX
// Drive motor: CIM controlled over CAN using a Talon SRX
SwerveModule module = new Mk2SwerveModuleBuilder(new Vector2(5.0, 5.0))
    .angleEncoder(new AnalogInput(0), -Math.toRadians(118.1114))
    .angleMotor(new TalonSRX(4), Mk2SwerveModuleBuilder.MotorType.CIM)
    .driveMotor(new TalonSRX(5), Mk2SwerveModuleBuilder.MotorType.CIM)
    .build();
```