### PR TITLE
Added more constructors to the Limelight Driver

### DIFF
--- a/robot/src/main/java/org/frcteam2910/common/robot/drivers/Limelight.java
+++ b/robot/src/main/java/org/frcteam2910/common/robot/drivers/Limelight.java
@@ -26,14 +26,14 @@ public final class Limelight {
     private final NetworkTableEntry snapshot;
 
     /*
-     * This method creates an instance of the Limelight, assuming the name is "limelight"
+     * Creates an instance of the Limelight, assuming the name is "limelight"
      */
     public Limelight() {
         this(NetworkTableInstance.getDefault().getTable("limelight"));
     }
 
     /*
-     * This is a method that creates an instance of the Limelight class given the name of the Limelight. For example,
+     * Creates an instance of the Limelight class given the name of the Limelight. For example,
      * if the Limelight is called "limelight-cargo", pass in "cargo".
      * @param name The name of the Limelight
      */
@@ -42,7 +42,7 @@ public final class Limelight {
     }
 
     /*
-     * This method creates an instance of the Limelight class given its NetworkTable
+     * Creates an instance of the Limelight class given its NetworkTable
      * @param table The Networktable used to create the Limelight
      */
     public Limelight(NetworkTable table) {
@@ -174,10 +174,7 @@ public final class Limelight {
     }
 
     /*
-     * Changes what the Limelight streams - either the standard stream, PIP_MAIN (The secondary camera stream is placed
-     * in the lower-right corner of the primary camera stream), or PIP_SECONDARY (The primary camera stream is placed in
-     * the lower-right corner of the secondary camera stream)
-     * @returns nothing
+     * Changes what the Limelight streams
      */
     public void setStreamMode(StreamMode mode) {
         switch (mode) {
@@ -202,37 +199,55 @@ public final class Limelight {
 
     /*
      * Represents the different operating modes of the Limelight
-     * VISION - brings the exposure down and runs the pipeline
-     * DRIVER - disables the pipeline, and brings the exposure up
      */
     public enum CamMode {
+        /*
+         * brings the exposure down and runs the pipeline
+         */
         VISION,
+        /*
+         * disables the pipeline, and brings the exposure up
+         */
         DRIVER
     }
 
     /*
      * Represents the different LED modes of the Limelight
-     * DEFAULT - sets it to whatever is specified in the pipeline,
-     * OFF - turns them off,
-     * ON - turns the LED's on
-     * BLINK - makes the LED's blink
      */
     public enum LedMode {
+        /*
+         * Sets the LED's to whatever is specified in the pipeline
+         */
         DEFAULT,
+        /*
+         * Turns the LED's on
+         */
         ON,
+        /*
+         * Turns the LED's off
+         */
         OFF,
+        /*
+         * Makes the LED's blink
+         */
         BLINK
     }
 
     /*
      * Represents the different streaming modes of the camera
-     * STANDARD - Side-by-side streams if a webcam is attached to Limelight
-     * PIP_MAIN - The secondary camera stream is placed in the lower-right corner of the primary camera stream
-     * PIP_SECONDARY - The primary camera stream is placed in the lower-right corner of the secondary camera stream
      */
     public enum StreamMode {
+        /*
+         * Side-by-side streams if a webcam is attached to Limelight
+         */
         STANDARD,
+        /*
+         * The secondary camera stream is placed in the lower-right corner of the primary camera stream
+         */
         PIP_MAIN,
+        /*
+         * The primary camera stream is placed in the lower-right corner of the secondary camera stream
+         */
         PIP_SECONDARY
     }
 }

--- a/robot/src/main/java/org/frcteam2910/common/robot/drivers/Limelight.java
+++ b/robot/src/main/java/org/frcteam2910/common/robot/drivers/Limelight.java
@@ -26,27 +26,24 @@ public final class Limelight {
     private final NetworkTableEntry snapshot;
 
     /*
-     * The default constructor for the Limelight class. Assumes the name of the Limelight is "limelight"
-     * @returns nothing
+     * This method creates a Limelight, assuming the name is "limelight"
      */
     public Limelight() {
         this(NetworkTableInstance.getDefault().getTable("limelight"));
     }
 
     /*
-     * This is a constructor that takes the name of the limelight. For example, if your Limelight is named
-     * "limelight-cargo", pass in "cargo"
+     * This is a method that takes the name of the Limelight. For example, if the Limelight is called "limelight-cargo",
+     * pass in "cargo".
      * @param name The name of the Limelight
-     * @returns nothing
      */
     public Limelight(String name) {
         this(NetworkTableInstance.getDefault().getTable("limelight-" + name));
     }
 
     /*
-     * This is a constructor that takes a NetworkTable instance
-     * @param table The NetworkTable instance to get values from the Limelight
-     * @returns nothing
+     * This method creates a Limelight with a NetworkTable
+     * @param table The Networktable to create the Limelight
      */
     public Limelight(NetworkTable table) {
         this.table = table;
@@ -69,15 +66,15 @@ public final class Limelight {
     }
 
     /*
-     * Returns true if the Limelight has a target, else false
-     * @returns A boolean value stating whether the Limelight has a target
+     * This method checks if the method has a target
+     * @returns Whether the Limelight has a target
      */
     public boolean hasTarget() {
         return MathUtils.epsilonEquals(tv.getDouble(0), 1);
     }
 
     /*
-     * Returns the area of the target divided by the size of the image
+     * This method gets the area of the target divided by the size of the image
      * @returns A value from 0.0 to 1.0 representing the target area
      */
     public double getTargetArea() {
@@ -85,32 +82,32 @@ public final class Limelight {
     }
 
     /*
-     * Returns the position of the target in degrees within the image
-     * @returns A Vector2 representing the position of the target
+     * This method returns the position of the target in radians within the image
+     * @returns The position of the target
      */
     public Vector2 getTargetPosition() {
         return new Vector2(Math.toRadians(tx.getDouble(0)), Math.toRadians(ty.getDouble(0)));
     }
 
     /*
-     * This gives the target's skew or rotation
-     * @returns The target's skew from -90 to 0 as a double
+     * This method gets the target's skew or rotation in degrees
+     * @returns The target's skew from -90 to 0 in degrees
      */
     public double getTargetSkew() {
         return ts.getDouble(0);
     }
 
     /*
-     * This returns the latency of the pipeline
-     * @returns The latency of the pipeline
+     * This method returns the latency of the pipeline in ms (milliseconds)
+     * @returns The latency of the pipeline in ms
      */
     public double getPipelineLatency() {
         return tl.getDouble(0.0);
     }
 
     /*
-     * Returns the vertices of the target
-     * @returns The vertices of the target as a array of points
+     * This method gets the vertices of the target
+     * @returns The vertices of the target
      */
     public double[][] getCorners() {
         double[] x = tcornx.getDoubleArray(new double[]{0.0, 0.0});
@@ -124,9 +121,7 @@ public final class Limelight {
     }
 
     /*
-     * Set the operating mode of the Limelight, either VISION (which runs the pipeline) or DRIVER (which disables
-     * the pipeline, and brings the exposure up)
-     * @returns nothing
+     * This method sets the operating mode of the Limelight
      */
     public void setCamMode(CamMode mode) {
         switch (mode) {
@@ -139,9 +134,7 @@ public final class Limelight {
     }
 
     /*
-     * Set the mode of the LED's of the Limelight. The options are DEFAULT, which sets it to whatever is specified in the pipeline,
-     * OFF, which turns them off, ON, which turns the LED's on, and BLINK, which makes the LED's blink
-     * @returns nothing
+     * This method sets the mode of the LED's of the Limelight
      */
     public void setLedMode(LedMode mode) {
         switch (mode) {
@@ -161,7 +154,7 @@ public final class Limelight {
     }
 
     /*
-     * Can control whether you want the Limelight to take snapshots or not. When it's taking snapshots, it will do it
+     * This method sets whether you want the Limelight to take snapshots or not. When it's taking snapshots, it will do it
      * twice every second.
      */
     public void setSnapshotsEnabled(boolean enabled) {
@@ -173,7 +166,7 @@ public final class Limelight {
     }
 
     /*
-     * Set which pipeline you want to use (0-9)
+     * This method sets which pipeline you want to use (0-9)
      * @returns nothing
      */
     public void setPipeline(int pipeline) {
@@ -201,17 +194,25 @@ public final class Limelight {
     }
 
     /*
-     * Returns the NetworkTable being used to get values from the Limelight
+     * This method gets the NetworkTable being used to get values from the Limelight
      */
     public NetworkTable getTable() {
         return table;
     }
 
+    /*
+     * It can be set to VISION (which runs the pipeline) or DRIVER
+     * (which disables the pipeline, and brings the exposure up).
+     */
     public enum CamMode {
         VISION,
         DRIVER
     }
 
+    /*
+     * The options are DEFAULT, which sets it to whatever is specified in the pipeline,
+     * OFF, which turns them off, ON, which turns the LED's on, and BLINK, which makes the LED's blink
+     */
     public enum LedMode {
         DEFAULT,
         ON,

--- a/robot/src/main/java/org/frcteam2910/common/robot/drivers/Limelight.java
+++ b/robot/src/main/java/org/frcteam2910/common/robot/drivers/Limelight.java
@@ -25,25 +25,25 @@ public final class Limelight {
     private final NetworkTableEntry stream;
     private final NetworkTableEntry snapshot;
 
-    /*
-     * Creates an instance of the Limelight, assuming the name is "limelight"
+    /**
+     * Creates an instance of the Limelight, assuming the name is "limelight".
      */
     public Limelight() {
         this(NetworkTableInstance.getDefault().getTable("limelight"));
     }
 
-    /*
+    /**
      * Creates an instance of the Limelight class given the name of the Limelight. For example,
      * if the Limelight is called "limelight-cargo", pass in "cargo".
-     * @param name The name of the Limelight
+     * @param name The name of the Limelight.
      */
     public Limelight(String name) {
         this(NetworkTableInstance.getDefault().getTable("limelight-" + name));
     }
 
-    /*
-     * Creates an instance of the Limelight class given its NetworkTable
-     * @param table The Networktable used to create the Limelight
+    /**
+     * Creates an instance of the Limelight class given its NetworkTable.
+     * @param table The NetworkTable used to create the Limelight.
      */
     public Limelight(NetworkTable table) {
         this.table = table;
@@ -65,49 +65,49 @@ public final class Limelight {
         snapshot = table.getEntry("snapshot");
     }
 
-    /*
-     * Checks if the method has a target
-     * @returns Whether the Limelight has a target
+    /**
+     * Checks if the method has a target.
+     * @returns Whether the Limelight has a target.
      */
     public boolean hasTarget() {
         return MathUtils.epsilonEquals(tv.getDouble(0), 1);
     }
 
-    /*
-     * Gets the area of the target divided by the size of the image
-     * @returns A value from 0.0 to 1.0 representing the target area
+    /**
+     * Gets the area of the target divided by the size of the image.
+     * @returns A value from 0.0 to 1.0 representing the target area.
      */
     public double getTargetArea() {
         return ta.getDouble(0);
     }
 
-    /*
-     * Gets the position of the target in radians within the image
-     * @returns The position of the target
+    /**
+     * Gets the position of the target in radians within the image.
+     * @returns The position of the target.
      */
     public Vector2 getTargetPosition() {
         return new Vector2(Math.toRadians(tx.getDouble(0)), Math.toRadians(ty.getDouble(0)));
     }
 
-    /*
-     * Gets the target's skew or rotation in degrees
-     * @returns The target's skew from -90 to 0 in degrees
+    /**
+     * Gets the target's skew or rotation in degrees.
+     * @returns The target's skew from -90 to 0 in degrees.
      */
     public double getTargetSkew() {
         return ts.getDouble(0);
     }
 
-    /*
-     * Gets the latency of the pipeline in ms (milliseconds)
-     * @returns The latency of the pipeline in ms
+    /**
+     * Gets the latency of the pipeline in ms (milliseconds).
+     * @returns The latency of the pipeline in ms.
      */
     public double getPipelineLatency() {
         return tl.getDouble(0.0);
     }
 
-    /*
-     * Gets the vertices of the target
-     * @returns The vertices of the target
+    /**
+     * Gets the vertices of the target.
+     * @returns The vertices of the target.
      */
     public double[][] getCorners() {
         double[] x = tcornx.getDoubleArray(new double[]{0.0, 0.0});
@@ -120,8 +120,9 @@ public final class Limelight {
         return corners;
     }
 
-    /*
-     * Sets the operating mode of the Limelight
+    /**
+     * Sets the operating mode of the Limelight.
+     * @param mode The operating mode the Limelight should be set to.
      */
     public void setCamMode(CamMode mode) {
         switch (mode) {
@@ -133,8 +134,9 @@ public final class Limelight {
         }
     }
 
-    /*
-     * Sets the mode of the LED's of the Limelight
+    /**
+     * Sets the mode of the LED's of the Limelight.
+     * @param mode The mode the LED's should be set to.
      */
     public void setLedMode(LedMode mode) {
         switch (mode) {
@@ -153,9 +155,10 @@ public final class Limelight {
         }
     }
 
-    /*
+    /**
      * Sets whether you want the Limelight to take snapshots or not. When it's taking snapshots, it will do it
      * twice every second.
+     * @param enabled Whether snapshots should be enabled.
      */
     public void setSnapshotsEnabled(boolean enabled) {
         if (enabled) {
@@ -165,16 +168,17 @@ public final class Limelight {
         }
     }
 
-    /*
-     * Sets which pipeline you want to use (0-9)
-     * @returns nothing
+    /**
+     * Sets which pipeline you want to use (0-9).
+     * @param pipeline The index of the desired pipeline.
      */
     public void setPipeline(int pipeline) {
         this.pipeline.setNumber(pipeline);
     }
 
-    /*
-     * Changes what the Limelight streams
+    /**
+     * Changes what the Limelight streams.
+     * @param mode What the Limelight should be streaming.
      */
     public void setStreamMode(StreamMode mode) {
         switch (mode) {
@@ -190,62 +194,62 @@ public final class Limelight {
         }
     }
 
-    /*
-     * Gets the NetworkTable being used to get values from the Limelight
+    /**
+     * Gets the NetworkTable being used to get values from the Limelight.
      */
     public NetworkTable getTable() {
         return table;
     }
 
-    /*
-     * Represents the different operating modes of the Limelight
+    /**
+     * Represents the different operating modes of the Limelight.
      */
     public enum CamMode {
-        /*
-         * brings the exposure down and runs the pipeline
+        /**
+         * Brings the exposure down and runs the pipeline
          */
         VISION,
-        /*
-         * disables the pipeline, and brings the exposure up
+        /**
+         * Disables the pipeline, and brings the exposure up
          */
         DRIVER
     }
 
-    /*
+    /**
      * Represents the different LED modes of the Limelight
      */
     public enum LedMode {
-        /*
+        /**
          * Sets the LED's to whatever is specified in the pipeline
          */
         DEFAULT,
-        /*
+        /**
          * Turns the LED's on
          */
         ON,
-        /*
+        /**
          * Turns the LED's off
          */
         OFF,
-        /*
+        /**
          * Makes the LED's blink
          */
         BLINK
     }
 
-    /*
+    /**
      * Represents the different streaming modes of the camera
      */
     public enum StreamMode {
-        /*
+        /**
          * Side-by-side streams if a webcam is attached to Limelight
          */
         STANDARD,
-        /*
+        /**
          * The secondary camera stream is placed in the lower-right corner of the primary camera stream
          */
         PIP_MAIN,
-        /*
+        /**
          * The primary camera stream is placed in the lower-right corner of the secondary camera stream
          */
         PIP_SECONDARY

--- a/robot/src/main/java/org/frcteam2910/common/robot/drivers/Limelight.java
+++ b/robot/src/main/java/org/frcteam2910/common/robot/drivers/Limelight.java
@@ -2,6 +2,7 @@ package org.frcteam2910.common.robot.drivers;
 
 import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableEntry;
+import edu.wpi.first.networktables.NetworkTableInstance;
 import org.frcteam2910.common.math.MathUtils;
 import org.frcteam2910.common.math.Vector2;
 
@@ -24,6 +25,29 @@ public final class Limelight {
     private final NetworkTableEntry stream;
     private final NetworkTableEntry snapshot;
 
+    /*
+     * The default constructor for the Limelight class. Assumes the name of the Limelight is "limelight"
+     * @returns nothing
+     */
+    public Limelight() {
+        this(NetworkTableInstance.getDefault().getTable("limelight"));
+    }
+
+    /*
+     * This is a constructor that takes the name of the limelight. For example, if your Limelight is named
+     * "limelight-cargo", pass in "cargo"
+     * @param name The name of the Limelight
+     * @returns nothing
+     */
+    public Limelight(String name) {
+        this(NetworkTableInstance.getDefault().getTable("limelight-" + name));
+    }
+
+    /*
+     * This is a constructor that takes a NetworkTable instance
+     * @param table The NetworkTable instance to get values from the Limelight
+     * @returns nothing
+     */
     public Limelight(NetworkTable table) {
         this.table = table;
 
@@ -44,26 +68,50 @@ public final class Limelight {
         snapshot = table.getEntry("snapshot");
     }
 
+    /*
+     * Returns true if the Limelight has a target, else false
+     * @returns A boolean value stating whether the Limelight has a target
+     */
     public boolean hasTarget() {
         return MathUtils.epsilonEquals(tv.getDouble(0), 1);
     }
 
+    /*
+     * Returns the area of the target divided by the size of the image
+     * @returns A value from 0.0 to 1.0 representing the target area
+     */
     public double getTargetArea() {
         return ta.getDouble(0);
     }
 
+    /*
+     * Returns the position of the target in degrees within the image
+     * @returns A Vector2 representing the position of the target
+     */
     public Vector2 getTargetPosition() {
         return new Vector2(Math.toRadians(tx.getDouble(0)), Math.toRadians(ty.getDouble(0)));
     }
 
+    /*
+     * This gives the target's skew or rotation
+     * @returns The target's skew from -90 to 0 as a double
+     */
     public double getTargetSkew() {
         return ts.getDouble(0);
     }
 
+    /*
+     * This returns the latency of the pipeline
+     * @returns The latency of the pipeline
+     */
     public double getPipelineLatency() {
         return tl.getDouble(0.0);
     }
 
+    /*
+     * Returns the vertices of the target
+     * @returns The vertices of the target as a array of points
+     */
     public double[][] getCorners() {
         double[] x = tcornx.getDoubleArray(new double[]{0.0, 0.0});
         double[] y = tcorny.getDoubleArray(new double[]{0.0, 0.0});
@@ -75,6 +123,11 @@ public final class Limelight {
         return corners;
     }
 
+    /*
+     * Set the operating mode of the Limelight, either VISION (which runs the pipeline) or DRIVER (which disables
+     * the pipeline, and brings the exposure up)
+     * @returns nothing
+     */
     public void setCamMode(CamMode mode) {
         switch (mode) {
             case VISION:
@@ -85,6 +138,11 @@ public final class Limelight {
         }
     }
 
+    /*
+     * Set the mode of the LED's of the Limelight. The options are DEFAULT, which sets it to whatever is specified in the pipeline,
+     * OFF, which turns them off, ON, which turns the LED's on, and BLINK, which makes the LED's blink
+     * @returns nothing
+     */
     public void setLedMode(LedMode mode) {
         switch (mode) {
             case DEFAULT:
@@ -102,6 +160,10 @@ public final class Limelight {
         }
     }
 
+    /*
+     * Can control whether you want the Limelight to take snapshots or not. When it's taking snapshots, it will do it
+     * twice every second.
+     */
     public void setSnapshotsEnabled(boolean enabled) {
         if (enabled) {
             snapshot.setNumber(1);
@@ -110,10 +172,20 @@ public final class Limelight {
         }
     }
 
+    /*
+     * Set which pipeline you want to use (0-9)
+     * @returns nothing
+     */
     public void setPipeline(int pipeline) {
         this.pipeline.setNumber(pipeline);
     }
 
+    /*
+     * Changes what the Limelight streams - either the standard stream, PIP_MAIN (The secondary camera stream is placed
+     * in the lower-right corner of the primary camera stream), or PIP_SECONDARY (The primary camera stream is placed in
+     * the lower-right corner of the secondary camera stream)
+     * @returns nothing
+     */
     public void setStreamMode(StreamMode mode) {
         switch (mode) {
             case STANDARD:
@@ -128,6 +200,9 @@ public final class Limelight {
         }
     }
 
+    /*
+     * Returns the NetworkTable being used to get values from the Limelight
+     */
     public NetworkTable getTable() {
         return table;
     }

--- a/robot/src/main/java/org/frcteam2910/common/robot/drivers/Limelight.java
+++ b/robot/src/main/java/org/frcteam2910/common/robot/drivers/Limelight.java
@@ -26,15 +26,15 @@ public final class Limelight {
     private final NetworkTableEntry snapshot;
 
     /*
-     * This method creates a Limelight, assuming the name is "limelight"
+     * This method creates an instance of the Limelight, assuming the name is "limelight"
      */
     public Limelight() {
         this(NetworkTableInstance.getDefault().getTable("limelight"));
     }
 
     /*
-     * This is a method that takes the name of the Limelight. For example, if the Limelight is called "limelight-cargo",
-     * pass in "cargo".
+     * This is a method that creates an instance of the Limelight class given the name of the Limelight. For example,
+     * if the Limelight is called "limelight-cargo", pass in "cargo".
      * @param name The name of the Limelight
      */
     public Limelight(String name) {
@@ -42,8 +42,8 @@ public final class Limelight {
     }
 
     /*
-     * This method creates a Limelight with a NetworkTable
-     * @param table The Networktable to create the Limelight
+     * This method creates an instance of the Limelight class given its NetworkTable
+     * @param table The Networktable used to create the Limelight
      */
     public Limelight(NetworkTable table) {
         this.table = table;
@@ -66,7 +66,7 @@ public final class Limelight {
     }
 
     /*
-     * This method checks if the method has a target
+     * Checks if the method has a target
      * @returns Whether the Limelight has a target
      */
     public boolean hasTarget() {
@@ -74,7 +74,7 @@ public final class Limelight {
     }
 
     /*
-     * This method gets the area of the target divided by the size of the image
+     * Gets the area of the target divided by the size of the image
      * @returns A value from 0.0 to 1.0 representing the target area
      */
     public double getTargetArea() {
@@ -82,7 +82,7 @@ public final class Limelight {
     }
 
     /*
-     * This method returns the position of the target in radians within the image
+     * Gets the position of the target in radians within the image
      * @returns The position of the target
      */
     public Vector2 getTargetPosition() {
@@ -90,7 +90,7 @@ public final class Limelight {
     }
 
     /*
-     * This method gets the target's skew or rotation in degrees
+     * Gets the target's skew or rotation in degrees
      * @returns The target's skew from -90 to 0 in degrees
      */
     public double getTargetSkew() {
@@ -98,7 +98,7 @@ public final class Limelight {
     }
 
     /*
-     * This method returns the latency of the pipeline in ms (milliseconds)
+     * Gets the latency of the pipeline in ms (milliseconds)
      * @returns The latency of the pipeline in ms
      */
     public double getPipelineLatency() {
@@ -106,7 +106,7 @@ public final class Limelight {
     }
 
     /*
-     * This method gets the vertices of the target
+     * Gets the vertices of the target
      * @returns The vertices of the target
      */
     public double[][] getCorners() {
@@ -121,7 +121,7 @@ public final class Limelight {
     }
 
     /*
-     * This method sets the operating mode of the Limelight
+     * Sets the operating mode of the Limelight
      */
     public void setCamMode(CamMode mode) {
         switch (mode) {
@@ -134,7 +134,7 @@ public final class Limelight {
     }
 
     /*
-     * This method sets the mode of the LED's of the Limelight
+     * Sets the mode of the LED's of the Limelight
      */
     public void setLedMode(LedMode mode) {
         switch (mode) {
@@ -154,7 +154,7 @@ public final class Limelight {
     }
 
     /*
-     * This method sets whether you want the Limelight to take snapshots or not. When it's taking snapshots, it will do it
+     * Sets whether you want the Limelight to take snapshots or not. When it's taking snapshots, it will do it
      * twice every second.
      */
     public void setSnapshotsEnabled(boolean enabled) {
@@ -166,7 +166,7 @@ public final class Limelight {
     }
 
     /*
-     * This method sets which pipeline you want to use (0-9)
+     * Sets which pipeline you want to use (0-9)
      * @returns nothing
      */
     public void setPipeline(int pipeline) {
@@ -194,15 +194,16 @@ public final class Limelight {
     }
 
     /*
-     * This method gets the NetworkTable being used to get values from the Limelight
+     * Gets the NetworkTable being used to get values from the Limelight
      */
     public NetworkTable getTable() {
         return table;
     }
 
     /*
-     * It can be set to VISION (which runs the pipeline) or DRIVER
-     * (which disables the pipeline, and brings the exposure up).
+     * Represents the different operating modes of the Limelight
+     * VISION - brings the exposure down and runs the pipeline
+     * DRIVER - disables the pipeline, and brings the exposure up
      */
     public enum CamMode {
         VISION,
@@ -210,8 +211,11 @@ public final class Limelight {
     }
 
     /*
-     * The options are DEFAULT, which sets it to whatever is specified in the pipeline,
-     * OFF, which turns them off, ON, which turns the LED's on, and BLINK, which makes the LED's blink
+     * Represents the different LED modes of the Limelight
+     * DEFAULT - sets it to whatever is specified in the pipeline,
+     * OFF - turns them off,
+     * ON - turns the LED's on
+     * BLINK - makes the LED's blink
      */
     public enum LedMode {
         DEFAULT,
@@ -220,6 +224,12 @@ public final class Limelight {
         BLINK
     }
 
+    /*
+     * Represents the different streaming modes of the camera
+     * STANDARD - Side-by-side streams if a webcam is attached to Limelight
+     * PIP_MAIN - The secondary camera stream is placed in the lower-right corner of the primary camera stream
+     * PIP_SECONDARY - The primary camera stream is placed in the lower-right corner of the secondary camera stream
+     */
     public enum StreamMode {
         STANDARD,
         PIP_MAIN,


### PR DESCRIPTION
Added two constructors for the Limelight driver, a default constructor that assumes the name of the Limelight is "limelight", and another that will actually take the name of the Limelight (e.g., if your Limelight is called "limelight-cargo", you simply pass "cargo" to the constructor. Also added documentation for the methods.

<!--
Do not forget to reference any issues that you wish your PR to close if you are
creating your PR in response to a github issue. You can do this by:
  * Referring to the PR number in your commit "Fixes #00", "Closes #00"
  * Referring to the PR number in your pull request using the same style as above
For more info about how to close issues with keywords review the link below
https://help.github.com/articles/closing-issues-using-keywords/
-->